### PR TITLE
switch to poetry-core build backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,5 +62,5 @@ python = ">=2.6 || >=3.0"
 pytest = "==6.0.1"
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=0.12"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Switch the build backend from poetry to poetry-core.  This is a lighter
version that's more suitable for PEP 517 builds.  The resulting
artifacts are the same but poetry-core has less dependencies (as it does
not pull the whole package manager in) and therefore wheel builds
are much faster.